### PR TITLE
feat: add clipboard paste support

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,3 +5,9 @@ Temu Local Cropper — 3:4 vertical & 1:1
 - Default sizes: 3:4 → 1500x2000; 1:1 → 1500x1500 (you can edit).
 - Choose a base folder once; each batch saves into {base}/{SPU}/.
 - Uses File System Access API: Chrome/Edge latest recommended. Use "Download current" if unsupported.
+- 支持剪贴板粘贴图片（点击页面或预览区后按 Ctrl/Cmd+V）。
+
+测试说明：
+- 在桌面 Chrome/Firefox：打开页面，点击预览区域后按 Ctrl/Cmd+V（从图片查看器或网页复制图片）→ 图片应被添加到缩略图并可裁剪。
+- 复制图片文件（在文件管理器中复制）或在网页上右键“复制图片”后粘贴；也可以复制图片 URL 并粘贴（若跨域允许，将尝试下载并添加）。
+- 在不支持剪贴板读取的浏览器上仍可通过拖拽或「选择/拖入图片」按钮添加图片。

--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
     <div class="controls">
       <label>选择/拖入图片
         <input id="fileInput" type="file" accept="image/*" multiple>
+        <div class="muted" style="margin-top:6px; font-size:12px">或按 <strong>Ctrl/Cmd</strong>+<strong>V</strong> 粘贴图片</div>
       </label>
       <div class="row">
         <label>SPU（用于命名/子目录）
@@ -90,7 +91,7 @@
     </div>
   </section>
   <section class="panel">
-    <div id="canvasWrap" class="drop-target" title="可直接把图片从其它标签页拖到此区域">
+    <div id="canvasWrap" class="drop-target" title="可直接把图片从其它标签页拖到此区域" tabindex="0" role="button" aria-label="可点击并按 Ctrl/Cmd+V 粘贴图片">
       <img id="previewImg" alt="预览将显示在这里">
     </div>
     <div class="muted" style="margin-top:8px">右键预览可删除当前；右键缩略图可删除；缩略图右上角“×”可删除。</div>
@@ -439,6 +440,64 @@ el('clear').addEventListener('click', clearAll);
 previewImg.addEventListener('contextmenu', (e)=>{
   e.preventDefault();
   if(activeIndex>=0) removeAt(activeIndex);
+});
+
+// 粘贴支持：从剪贴板读取图片并复用上传逻辑（优先使用同步 clipboardData，回退到 navigator.clipboard.read）
+document.addEventListener('paste', async (e)=>{
+  const clipboard = e.clipboardData || window.clipboardData;
+  if (!clipboard) return;
+
+  const filesFromClipboard = [];
+  // 优先处理 clipboardData 的 items（同步）
+  if(clipboard.items && clipboard.items.length){
+    for(const it of clipboard.items){
+      try{
+        if(it.kind === 'file' && it.type && it.type.startsWith('image/')){
+          const file = it.getAsFile ? it.getAsFile() : it.getAsBlob && it.getAsBlob();
+          if(file) filesFromClipboard.push(file);
+        }
+      }catch(_){/* ignore malformed items */}
+    }
+  }
+
+  // 回退：尝试 navigator.clipboard.read（需权限、HTTPS）
+  if(filesFromClipboard.length === 0 && navigator.clipboard && navigator.clipboard.read){
+    try{
+      const clipboardItems = await navigator.clipboard.read();
+      for(const clipIt of clipboardItems){
+        for(const type of clipIt.types){
+          if(type.startsWith('image/')){
+            const blob = await clipIt.getType(type);
+            const file = new File([blob], 'clipboard.' + (type.split('/')[1] || 'png'), {type: blob.type});
+            filesFromClipboard.push(file);
+          }
+        }
+      }
+    }catch(err){ /* permissions or unsupported - ignore */ }
+  }
+
+  // 额外尝试：粘贴 URL（文本）指向图片
+  if(filesFromClipboard.length === 0){
+    try{
+      const text = clipboard.getData && clipboard.getData('text/plain');
+      if(text && /^https?:\/\//.test(text)){
+        const res = await fetch(text, {mode:'cors'});
+        const blob = await res.blob();
+        if(/^image\//.test(blob.type)){
+          const f = new File([blob], 'pasted-remote.jpg', {type: blob.type});
+          filesFromClipboard.push(f);
+        }
+      }
+    }catch(err){ /* ignore cross-origin or fetch errors */ }
+  }
+
+  if(filesFromClipboard.length){
+    const dropInPreview = document.activeElement && (document.activeElement === canvasWrap || canvasWrap.contains(document.activeElement));
+    addFiles(filesFromClipboard, dropInPreview);
+    e.preventDefault();
+    showToast('已添加粘贴图片');
+    return;
+  }
 });
 
 // 整页拖拽支持


### PR DESCRIPTION
Adds clipboard paste support for images: UI hint, focusable preview area, and clipboard 'paste' handler that reuses the existing addFiles logic. Includes README test instructions.